### PR TITLE
feat: 統合地図インターフェースとカスタム地図コントロールの実装

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,14 @@ app = FastAPI(title="Namecard Places API")
 # CORS設定
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3001", "http://localhost:3000", "http://127.0.0.1:3001", "http://127.0.0.1:3000"],
+    allow_origins=[
+        "http://localhost:3001", 
+        "http://localhost:3000", 
+        "http://127.0.0.1:3001", 
+        "http://127.0.0.1:3000",
+        "http://192.168.56.1:3001",
+        "http://192.168.56.1:3000"
+    ],
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
     allow_headers=["*"],


### PR DESCRIPTION
- 記録モードと表示モードを統合し、同じ画面でモード切り替えが可能に
- モード切り替えボタンを追加（表示モード/記録モード）
- カスタム地図コントロールを実装（ズームイン/ズームアウト/初期位置リセット）
- デフォルトのOpenLayersコントロールを無効化し、見栄えの良いボタンスタイルに変更
- 新機能に対応したテストケースを追加（6件）
- CORS設定にIPアドレスベースのアクセスを追加
- API接続設定を環境変数対応

テスト結果: 17/17件パス
動作確認: フロントエンド・バックエンド接続正常